### PR TITLE
Refactoring ClientCredentials type

### DIFF
--- a/clientcredentials/client_credentials.go
+++ b/clientcredentials/client_credentials.go
@@ -2,6 +2,21 @@ package clientcredentials
 
 // ClientCredentials represents OAuth 2.0 client credentials.
 type ClientCredentials struct {
-	ClientID     string
-	ClientSecret string
+	clientID     string
+	clientSecret string
+}
+
+func NewClientCredentials(clientID, clientSecret string) *ClientCredentials {
+	return &ClientCredentials{
+		clientID:     clientID,
+		clientSecret: clientSecret,
+	}
+}
+
+func (cc *ClientCredentials) ClientID() string {
+	return cc.clientID
+}
+
+func (cc *ClientCredentials) ClientSecret() string {
+	return cc.clientSecret
 }

--- a/clientcredentials/client_credentials_creator.go
+++ b/clientcredentials/client_credentials_creator.go
@@ -26,8 +26,5 @@ func (ccc *ClientCredentialsCreator) CreateClientCredentials() (*ClientCredentia
 		return nil, err
 	}
 
-	return &ClientCredentials{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-	}, nil
+	return NewClientCredentials(clientID, clientSecret), nil
 }

--- a/clientcredentials/client_credentials_creator_test.go
+++ b/clientcredentials/client_credentials_creator_test.go
@@ -47,11 +47,11 @@ func TestCreateClientCredentials_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cc.ClientID != expectedID {
-		t.Errorf("expected ClientID %q, got %q", expectedID, cc.ClientID)
+	if cc.ClientID() != expectedID {
+		t.Errorf("expected ClientID %q, got %q", expectedID, cc.ClientID())
 	}
-	if cc.ClientSecret != expectedSecret {
-		t.Errorf("expected ClientSecret %q, got %q", expectedSecret, cc.ClientSecret)
+	if cc.ClientSecret() != expectedSecret {
+		t.Errorf("expected ClientSecret %q, got %q", expectedSecret, cc.ClientSecret())
 	}
 }
 

--- a/cmd/gst/cmd/client_credentials_create.go
+++ b/cmd/gst/cmd/client_credentials_create.go
@@ -49,9 +49,9 @@ var createClientCredentialsCmd = &cobra.Command{
 			}
 
 			fmt.Println("Client ID:")
-			fmt.Printf("%s\n", cc.ClientID)
+			fmt.Printf("%s\n", cc.ClientID())
 			fmt.Println("Client Secret:")
-			fmt.Printf("%s\n", cc.ClientSecret)
+			fmt.Printf("%s\n", cc.ClientSecret())
 			fmt.Println("**********************************************************")
 		}
 

--- a/cmd/gst/cmd/di_test.go
+++ b/cmd/gst/cmd/di_test.go
@@ -19,10 +19,10 @@ func TestBuildClientCredentialsCreator_UUIDv7(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error creating credentials: %v", err)
 	}
-	if cc.ClientID == "" {
+	if cc.ClientID() == "" {
 		t.Error("expected non-empty ClientID")
 	}
-	if cc.ClientSecret == "" {
+	if cc.ClientSecret() == "" {
 		t.Error("expected non-empty ClientSecret")
 	}
 }


### PR DESCRIPTION
Changed clientId and clientSecret to not be exported fields, and added func equivalents instead.